### PR TITLE
The HTML validator will only report 4xx errors.

### DIFF
--- a/script/docs-verify-docker-image/validate.sh
+++ b/script/docs-verify-docker-image/validate.sh
@@ -18,6 +18,7 @@ find "${PATH_TO_SITE}" -type f -not -path "/app/site/theme/*" \
 | xargs -0 -r -P "${NUMBER_OF_CPUS}" -I '{}' \
   htmlproofer \
   --check-html \
+  --only_4xx=true \
   --alt_ignore="/traefik.logo.png/" \
   --url-ignore "/localhost:/,/127.0.0.1:/,/fonts.gstatic.com/,/.minikube/,/github.com\/containous\/traefik\/*edit*/,/github.com\/containous\/traefik\/$/" \
   '{}'


### PR DESCRIPTION
Ref. https://github.com/gjtorikian/html-proofer#configuration